### PR TITLE
Fix import cleanup in lexicon builder

### DIFF
--- a/build_lexicon.py
+++ b/build_lexicon.py
@@ -2,7 +2,6 @@ import argparse
 import gzip
 import pandas as pd
 import re
-from glob import glob
 from phonemizer import phonemize
 
 PH_DISCRET = {"ə", "j", "w"}


### PR DESCRIPTION
## Summary
- remove unused `glob` import

`download_datasets.py` does not exist in the repository, and `rimotron.py` does not import `Iterable`.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f91723c2c832387d59462dea2e8e3